### PR TITLE
fix: [Map] 문 스프라이트/콜라이더 위치 오차 및 중복 생성 문제 수정

### DIFF
--- a/Project_LoL/Assets/_Prefabs/JJH/Door.prefab
+++ b/Project_LoL/Assets/_Prefabs/JJH/Door.prefab
@@ -31,9 +31,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7719157728336742984}
-  - {fileID: 8785224073985823774}
-  - {fileID: 7812562491572808377}
-  - {fileID: 7811263817319158720}
+  - {fileID: 5510022061874153332}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &4875787986999998120
@@ -48,6 +46,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e51e5334fa592b047bd740aa4cd52ac5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::DoorObject
+  _colliderThickness: 1
+  _spriteSpacing: 2
 --- !u!1 &1325638086076281141
 GameObject:
   m_ObjectHideFlags: 0
@@ -142,7 +142,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &7812562491572808377
 Transform:
   m_ObjectHideFlags: 0
@@ -156,7 +156,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 35712225174999812}
+  m_Father: {fileID: 5510022061874153332}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &8874300515474105186
 SpriteRenderer:
@@ -217,6 +217,40 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_SpriteSortPoint: 0
+--- !u!1 &7617538013752145314
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5510022061874153332}
+  m_Layer: 0
+  m_Name: SpriteContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5510022061874153332
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7617538013752145314}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8785224073985823774}
+  - {fileID: 7812562491572808377}
+  - {fileID: 7811263817319158720}
+  m_Father: {fileID: 35712225174999812}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7692198023215980361
 GameObject:
   m_ObjectHideFlags: 0
@@ -233,7 +267,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &7811263817319158720
 Transform:
   m_ObjectHideFlags: 0
@@ -247,7 +281,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 35712225174999812}
+  m_Father: {fileID: 5510022061874153332}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &4461623232219034643
 SpriteRenderer:
@@ -324,7 +358,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &8785224073985823774
 Transform:
   m_ObjectHideFlags: 0
@@ -338,7 +372,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 35712225174999812}
+  m_Father: {fileID: 5510022061874153332}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &1704776283291763955
 SpriteRenderer:

--- a/Project_LoL/Assets/_Prefabs/JJH/MapManager.prefab
+++ b/Project_LoL/Assets/_Prefabs/JJH/MapManager.prefab
@@ -45,6 +45,7 @@ GameObject:
   - component: {fileID: 928597045972814894}
   - component: {fileID: 7947275424986238716}
   - component: {fileID: 7698904211471236959}
+  - component: {fileID: 1633184659188746655}
   m_Layer: 0
   m_Name: MapManager
   m_TagString: Untagged
@@ -137,7 +138,6 @@ MonoBehaviour:
   _objectPool: {fileID: 7698904211471236959}
   _doorPrefab: {fileID: 391623070118702739, guid: f7a7022b352f1ff43b133cda1fd42254, type: 3}
   _doorRoot: {fileID: 8480314937181534272}
-  _doorWallOffset: 0.5
 --- !u!114 &7698904211471236959
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -151,6 +151,23 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::MapObjectPool
   _defaultPrewarmCount: 20
+--- !u!114 &1633184659188746655
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2754165553543735386}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b6d5cda6cdd3d65428f21a87b91a46b1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::RoomCombatHandler
+  _wallMargin: 1
+  _doorExcludeRadius: 3
+  _monsterSpacing: 2
+  _tileGenerator: {fileID: 928597045972814894}
+  _doorController: {fileID: 7947275424986238716}
 --- !u!1 &7734492493679460797
 GameObject:
   m_ObjectHideFlags: 0

--- a/Project_LoL/Assets/_Recovery.meta
+++ b/Project_LoL/Assets/_Recovery.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 10ec694e1d4315f42b28a9269fb3a1f5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Project_LoL/Assets/_Recovery/0.unity
+++ b/Project_LoL/Assets/_Recovery/0.unity
@@ -298,6 +298,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7947275424986238716, guid: 7f6bbc0ea7783234b9fb6de66449426c, type: 3}
+      propertyPath: _doorWallOffset
+      value: 0.5
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -314,8 +318,8 @@ GameObject:
   - component: {fileID: 635812606}
   - component: {fileID: 635812605}
   - component: {fileID: 635812608}
+  - component: {fileID: 635812607}
   - component: {fileID: 635812609}
-  - component: {fileID: 635812610}
   m_Layer: 6
   m_Name: Player
   m_TagString: Player
@@ -397,6 +401,42 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &635812607
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 635812604}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_Radius: 0.5
 --- !u!50 &635812608
 Rigidbody2D:
   serializedVersion: 5
@@ -437,52 +477,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::TempMove
   _speed: 10
---- !u!61 &635812610
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 635812604}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1, y: 1}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
 --- !u!1 &844073196
 GameObject:
   m_ObjectHideFlags: 0

--- a/Project_LoL/Assets/_Recovery/0.unity.meta
+++ b/Project_LoL/Assets/_Recovery/0.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e01c238d197f61c4eb514093ef669063
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Project_LoL/Assets/_Scripts/JJH/Combat/RoomTrigger.cs
+++ b/Project_LoL/Assets/_Scripts/JJH/Combat/RoomTrigger.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using UnityEngine;
 
 // 방 단위 플레이어 진입 감지
@@ -10,19 +11,20 @@ public class RoomTrigger : MonoBehaviour
     private void OnTriggerEnter2D(Collider2D other)
     {
         if (!other.CompareTag("Player")) return;
-        
         if (room == null || mapManager == null || doorController == null) return;
-
         if (room.roomData.roomType != RoomType.Combat) return;
 
         RoomRuntimeData data = mapManager.GetRuntimeData(room);
         if (data == null) return;
-
-        // 이미 진행 중이거나 클리어된 방은 무시
         if (data.state != RoomState.Unvisited) return;
 
-        // 방 진입 시 바로 문 닫기 (몬스터 수와 무관)
-        doorController.CloseDoors(room);
+        StartCoroutine(CloseDoorsDelayed());
         RoomClearManager.Instance?.StartRoom(room);
+    }
+
+    private IEnumerator CloseDoorsDelayed()
+    {
+        yield return new WaitForSeconds(0.5f);
+        doorController.CloseDoors(room);
     }
 }

--- a/Project_LoL/Assets/_Scripts/JJH/Core/ConnectionPlanner.cs
+++ b/Project_LoL/Assets/_Scripts/JJH/Core/ConnectionPlanner.cs
@@ -151,7 +151,7 @@ public class ConnectionPlanner : MonoBehaviour
         if (!PathClear(tiles, a, b, width, isVertical))
             return null;
  
-        return Wrap(tiles, ca.wallPos, cb.wallPos);
+        return Wrap(tiles, ca.tileWallPos, cb.tileWallPos);
     }
  
     private List<Vector2Int> TryLShape(
@@ -175,7 +175,7 @@ public class ConnectionPlanner : MonoBehaviour
             var tiles = ConcatLines(s, corner, e);
             if (!PathClear(tiles, a, b, width, isVertical)) continue;
  
-            return Wrap(tiles, ca.wallPos, cb.wallPos);
+            return Wrap(tiles, ca.tileWallPos, cb.tileWallPos);
         }
  
         return null;
@@ -208,7 +208,7 @@ public class ConnectionPlanner : MonoBehaviour
             var tiles = ConcatLines(s, p1, p2, e);
             if (!PathClear(tiles, a, b, width, isVertical)) continue;
  
-            return Wrap(tiles, ca.wallPos, cb.wallPos);
+            return Wrap(tiles, ca.tileWallPos, cb.tileWallPos);
         }
  
         for (int midY = yMin; midY <= yMax; midY += yStep)
@@ -222,7 +222,7 @@ public class ConnectionPlanner : MonoBehaviour
             var tiles = ConcatLines(s, p1, p2, e);
             if (!PathClear(tiles, a, b, width, isVertical)) continue;
  
-            return Wrap(tiles, ca.wallPos, cb.wallPos);
+            return Wrap(tiles, ca.tileWallPos, cb.tileWallPos);
         }
  
         return null;
@@ -321,18 +321,22 @@ public class ConnectionPlanner : MonoBehaviour
     {
         RoomNode lower = a.gridOrigin.y < b.gridOrigin.y ? a : b;
         RoomNode upper = lower == a ? b : a;
- 
+
         RectInt lb = _roomBounds[lower];
         RectInt ub = _roomBounds[upper];
- 
+
         int cx = lb.xMin + lb.width / 2;
         var wallLower = new Vector2Int(cx, lb.yMax);
         var wallUpper = new Vector2Int(cx, ub.yMin - 1);
- 
+
         var ca = new DoorCandidate(wallLower, DoorDir.Up, lower);
         var cb = new DoorCandidate(wallUpper, DoorDir.Down, upper);
-        var corridor = Wrap(MakeLine(ca.entrance, cb.entrance), ca.wallPos, cb.wallPos);
- 
+
+        var corridor = Wrap(MakeLine(ca.entrance, cb.entrance), ca.tileWallPos, cb.tileWallPos);
+
+        ca.RecalcWallPos(_bossCorridorWidth);
+        cb.RecalcWallPos(_bossCorridorWidth);
+
         return new ConnectionResult
         {
             roomA = lower,

--- a/Project_LoL/Assets/_Scripts/JJH/Core/DoorObject.cs
+++ b/Project_LoL/Assets/_Scripts/JJH/Core/DoorObject.cs
@@ -1,61 +1,85 @@
 using UnityEngine;
- 
+
 public class DoorObject : MonoBehaviour
 {
     [SerializeField] private float _colliderThickness = 1f;
     [SerializeField] private float _spriteSpacing = 2f;
- 
+
     private BoxCollider2D _collider;
     private GameObject[] _activeSprites;
- 
+    private Transform[] _spriteTransforms;
+    private Transform _spriteContainer;
+
     private void Awake()
     {
         _collider = GetComponentInChildren<BoxCollider2D>(true);
+        _spriteContainer = transform.Find("SpriteContainer");
+
+        _spriteTransforms = new Transform[3];
+        for (int i = 1; i <= 3; i++)
+            _spriteTransforms[i - 1] = transform.Find($"SpriteContainer/DoorSprite_{i}");
     }
- 
-    public void Setup(int width)
+
+    public void Setup(int width, DoorDir dir)
     {
+        if (_spriteContainer != null)
+            _spriteContainer.rotation = Quaternion.identity;
+
+        bool isVertical = dir == DoorDir.Up || dir == DoorDir.Down;
+        float sign = (dir == DoorDir.Up || dir == DoorDir.Left) ? -1f : 1f;
+
         if (_collider != null)
         {
-            _collider.size = new Vector2(width, _colliderThickness);
-            _collider.offset = new Vector2((width - 1) / 2f, 0f);
+            if (isVertical)
+            {
+                _collider.size = new Vector2(width, _colliderThickness);
+                _collider.offset = new Vector2(sign * (width - 1) / 2f, 0f);
+            }
+            else
+            {
+                _collider.size = new Vector2(_colliderThickness, width);
+                _collider.offset = new Vector2(0f, sign * (width - 1) / 2f);
+            }
             _collider.gameObject.SetActive(false);
         }
- 
+
         int spriteCount = Mathf.CeilToInt(width / 2f);
         _activeSprites = new GameObject[spriteCount];
- 
+
         for (int i = 1; i <= 3; i++)
         {
-            Transform spriteObj = transform.Find($"DoorSprite_{i}");
+            Transform spriteObj = _spriteTransforms[i - 1];
             if (spriteObj == null) continue;
- 
+
             bool active = i <= spriteCount;
             spriteObj.gameObject.SetActive(false);
- 
             if (!active) continue;
- 
+
             float localX = (i * _spriteSpacing) - (_spriteSpacing / 2f) - 0.5f;
-            spriteObj.localPosition = new Vector3(localX, 0f, 0f);
+
+            spriteObj.localPosition = isVertical
+                ? new Vector3(sign * localX, 0f, 0f)
+                : new Vector3(0f, sign * localX, 0f);
+
             _activeSprites[i - 1] = spriteObj.gameObject;
         }
     }
- 
+
     public void Close()
     {
         if (_collider != null)
             _collider.gameObject.SetActive(true);
- 
+
         if (_activeSprites == null) return;
         foreach (var s in _activeSprites)
             if (s != null) s.SetActive(true);
     }
- 
+
     public void Open()
     {
         if (_collider != null)
             _collider.gameObject.SetActive(false);
- 
+
         if (_activeSprites == null) return;
         foreach (var s in _activeSprites)
             if (s != null) s.SetActive(false);

--- a/Project_LoL/Assets/_Scripts/JJH/Data/ConnectionModels.cs
+++ b/Project_LoL/Assets/_Scripts/JJH/Data/ConnectionModels.cs
@@ -22,19 +22,21 @@ public class DoorCandidate
     
     public void RecalcWallPos(int width)
     {
+        int half = width / 2;
+
         switch (dir)
         {
             case DoorDir.Up:
-                wallPos = new Vector2Int(wallPos.x, wallPos.y);
+                wallPos = new Vector2Int(tileWallPos.x + (width - half - 1), tileWallPos.y);
                 break;
             case DoorDir.Down:
-                wallPos = new Vector2Int(wallPos.x + (width - 1), wallPos.y + 1);
-                break;
-            case DoorDir.Left:
-                wallPos = new Vector2Int(wallPos.x + 1, wallPos.y);
+                wallPos = new Vector2Int(tileWallPos.x - half, tileWallPos.y);
                 break;
             case DoorDir.Right:
-                wallPos = new Vector2Int(wallPos.x, wallPos.y + (width - 1));
+                wallPos = new Vector2Int(tileWallPos.x, tileWallPos.y - half);
+                break;
+            case DoorDir.Left:
+                wallPos = new Vector2Int(tileWallPos.x, tileWallPos.y + (width - half - 1));
                 break;
         }
     }

--- a/Project_LoL/Assets/_Scripts/JJH/Generation/DoorController.cs
+++ b/Project_LoL/Assets/_Scripts/JJH/Generation/DoorController.cs
@@ -14,21 +14,40 @@ public class DoorController : MonoBehaviour
         _objectPool.ReleaseChildren(_doorRoot);
         _roomDoors.Clear();
 
+        var placed = new HashSet<(RoomNode, Vector2Int)>();
+
         foreach (var conn in connections)
         {
-            PlaceDoor(conn.doorA, conn.corridorWidth);
-            PlaceDoor(conn.doorB, conn.corridorWidth);
+            RegisterDoor(conn.doorA, conn.corridorWidth, placed);
+            RegisterDoor(conn.doorB, conn.corridorWidth, placed);
         }
+    }
+    
+    private void RegisterDoor(DoorCandidate door, int width, HashSet<(RoomNode, Vector2Int)> placed)
+    {
+        if (door == null) return;
+
+        if (door.owner != null)
+        {
+            if (!_roomDoors.ContainsKey(door.owner))
+                _roomDoors[door.owner] = new List<DoorObject>();
+        }
+
+        var key = (door.owner, door.wallPos);
+        if (!placed.Add(key)) return;
+
+        PlaceDoor(door, width);
     }
  
     private void PlaceDoor(DoorCandidate door, int width)
     {
         if (door == null) return;
- 
+
         Vector3 worldPos = CalcPos(door, width);
- 
+        Debug.Log($"dir:{door.dir} wallPos:{door.wallPos} width:{width} owner:{door.owner?.nodeId}");
         GameObject d = _objectPool.Spawn(_doorPrefab, _doorRoot, worldPos, Quaternion.identity);
- 
+        d.SetActive(false);
+
         float angle = door.dir switch
         {
             DoorDir.Up    => 0f,
@@ -36,17 +55,17 @@ public class DoorController : MonoBehaviour
             DoorDir.Left  => 90f,
             _             => -90f
         };
-        d.transform.rotation = Quaternion.Euler(0f, 0f, angle);
- 
+
         DoorObject doorObj = d.GetComponent<DoorObject>();
         if (doorObj != null)
-            doorObj.Setup(width);
- 
+            doorObj.Setup(width, door.dir);
+
+        d.SetActive(true);
+
         if (door.owner != null)
         {
             if (!_roomDoors.ContainsKey(door.owner))
                 _roomDoors[door.owner] = new List<DoorObject>();
- 
             if (doorObj != null)
                 _roomDoors[door.owner].Add(doorObj);
         }


### PR DESCRIPTION
- RecalcWallPos 방향별 부호 통일 (Up/Down/Left/Right 각각 올바른 축으로 수정)
- DoorObject.Setup에서 sign 분기 추가로 스프라이트/콜라이더 방향 수정
- DoorController 루트 오브젝트 회전 제거
- BuildDoors에서 owner+wallPos 기준 중복 문 생성 방지 처리